### PR TITLE
Remove cmdliner dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
         "dependency-env": "https://github.com/npm-ml/dependency-env.git",
         "substs": "https://github.com/yunxing/substs.git",
         "@opam-alpha/ocamlbuild": "*",
-        "@opam-alpha/cmdliner": "< 0.9.6",
         "nopam": "https://github.com/yunxing/nopam.git",
         "opam-installer-bin": "https://github.com/yunxing/opam-installer-bin.git"
     },


### PR DESCRIPTION
Hi!

`cmdliner` is an optional dependency, and uutf _conflicts_ with cmdliner < 0.9.6.
See https://github.com/ocaml/opam-repository/blob/2ffce85/packages/uutf/uutf.0.9.4/opam

If this repo is auto-generated, please republish 📦 Thanks.
